### PR TITLE
Adjust gh-sorter wait time `wait_before_complete` to less than 5 min

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ gh-actions-workflow-runs-sorter \
 | `--workflowFile` | the workflow file name running triggering the workflow | | 
 | `--workflow_run_to_return` | how many workflow runs do you want to visit per check | `20` |
 | `--wait_between_checks` | used in `shouldComplete` mode when `SHOULD_WAIT_FOR_PAST_RUN` is true - how long to wait before checking the status of workflow run with `previousRunId` again | `10s` |
-| `--wait_before_complete` | used in `shouldComplete` mode - how long to wait post-completion of workflow run with `previousRunId` | `300s` |
+| `--wait_before_complete` | used in `shouldComplete` mode - how long to wait post-completion of workflow run with `previousRunId` | `60s` |
 
 ## Explanation:
 Running this cli using the `shouldExecute` mode will return three variables `SHOULD_RUN_EXECUTE`, `SHOULD_WAIT_FOR_PAST_RUN`, and `PAST_RUN_ID`. All three variables are exportable using the cli output - note the command execution below. 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main(){
 	workflowFile         := flag.String("workflowFile", "cron_and_dispatch.yml", "workflow to link users to")
 	workflowRunsToReturn := flag.Int("workflow_run_to_return", 20, "number of workflow runs to return")
 	waitBetweenChecks    := flag.Int("wait_between_checks", 10, "how long, in seconds, to wait between checks on previous workflow run")
-    waitBeforeComplete   := flag.Float64("wait_before_complete", 300, "how long, in seconds, to wait after a completed previous workflow run")
+        waitBeforeComplete   := flag.Float64("wait_before_complete", 60, "how long, in seconds, to wait after a completed previous workflow run")
 
     flag.Parse()
 


### PR DESCRIPTION
Adjust the wait time before complete - how long to wait post-completion of workflow run with `previousRunId`.

Previous value: 300 seconds
New value: 60 seconds