### PR TITLE
Improvements: Better Handling Errors From Github Actions APIs

### DIFF
--- a/gh/createClient.go
+++ b/gh/createClient.go
@@ -1,29 +1,29 @@
 package gh
 
 import (
-	"context"
-	"os"
-	
-	"github.com/google/go-github/v47/github"
-	"golang.org/x/oauth2"
+    "context"
+    "os"
 
-	log "github.com/sirupsen/logrus"
+    "github.com/google/go-github/v47/github"
+    "golang.org/x/oauth2"
+
+    log "github.com/sirupsen/logrus"
 )
 
 func CreateClient() (context.Context, *github.Client) {
 
-	log.WithFields(log.Fields{
-	}).Info("Initializing Github client ...")
+    log.WithFields(log.Fields{
+    }).Info("Initializing Github client ...")
 
-	ctx := context.Background()
+    ctx := context.Background()
 
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("GH_TOKEN")},
-	)
+    ts := oauth2.StaticTokenSource(
+        &oauth2.Token{AccessToken: os.Getenv("GH_TOKEN")},
+    )
 
-	tc := oauth2.NewClient(ctx, ts)
+    tc := oauth2.NewClient(ctx, ts)
 
-	client := github.NewClient(tc)
+    client := github.NewClient(tc)
 
-	return ctx, client
+    return ctx, client
 }

--- a/gh/returnWorkflowRuns.go
+++ b/gh/returnWorkflowRuns.go
@@ -1,72 +1,73 @@
 package gh
 
 import (
-	"context"
-	"fmt"
-	
-	"github.com/google/go-github/v47/github"
-	
-	log "github.com/sirupsen/logrus"
+    "context"
+    "fmt"
+
+    "github.com/google/go-github/v47/github"
+
+    log "github.com/sirupsen/logrus"
 )
 
 func ReturnWorkflowRuns(branchName string, ctx context.Context, client *github.Client, owner string, repo string, workflowFile string, workflowRunsToReturn int) ([]*github.WorkflowRun, error) {
 
-	log.WithFields(log.Fields{
-		"repo":         repo,
-		"owner":        owner,
-		"workflowFile": workflowFile,
-		"workflowRunsToReturn": workflowRunsToReturn,
-	}).Info("Calling for last few runs from workflow...")
+    log.WithFields(log.Fields{
+        "repo":         repo,
+        "owner":        owner,
+        "workflowFile": workflowFile,
+        "workflowRunsToReturn": workflowRunsToReturn,
+    }).Info("Calling for last few runs from workflow...")
 
-	opts := &github.ListWorkflowRunsOptions{
-		Branch: branchName,
-		ListOptions: github.ListOptions{
-			Page: 1,
-			PerPage: workflowRunsToReturn,
-		},
-	}
+    opts := &github.ListWorkflowRunsOptions{
+        Branch: branchName,
+        ListOptions: github.ListOptions{
+            Page: 1,
+            PerPage: workflowRunsToReturn,
+        },
+    }
 
-	runs, res, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowFile, opts)
+    runs, res, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowFile, opts)
 
-	if res.StatusCode == 404 {
+    if res.StatusCode == 404 {
 
-		log.WithFields(log.Fields{
-			"repo":         repo,
-			"owner":        owner,
-			"workflowFile": workflowFile,
-			"workflowRunsToReturn": workflowRunsToReturn,
-		}).Warn("Workflow not found ...")
+        log.WithFields(log.Fields{
+            "Response Status":      res.StatusCode,
+            "repo":                 repo,
+            "owner":                owner,
+            "workflowFile":         workflowFile,
+            "workflowRunsToReturn": workflowRunsToReturn,
+        }).Warn("Workflow not found ...")
 
-		return nil, fmt.Errorf("Workflow not found")
+        return nil, fmt.Errorf("Workflow not found")
 
-	}
+    }
 
-	if res.StatusCode == 410 {
+    if res.StatusCode == 410 {
 
-		log.WithFields(log.Fields{
-			"repo":         repo,
-			"owner":        owner,
-			"workflowFile": workflowFile,
-			"workflowRunsToReturn": workflowRunsToReturn,
-		}).Warn("received 410 code: API Method Gone...")
-		
-		return nil, fmt.Errorf("API Method Gone")
-	}
+        log.WithFields(log.Fields{
+            "Response Status":      res.StatusCode,
+            "repo":                 repo,
+            "owner":                owner,
+            "workflowFile":         workflowFile,
+            "workflowRunsToReturn": workflowRunsToReturn,
+        }).Warn("received 410 code: API Method Gone...")
+
+        return nil, fmt.Errorf("API Method Gone")
+    }
 
 
-	if err != nil {
+    if err != nil {
 
-		return nil, err
-	
-	}
+        return nil, err
+    }
 
-	log.WithFields(log.Fields{
-		"repo":         repo,
-		"owner":        owner,
-		"workflowFile": workflowFile,
-		"workflowRunsToReturn": workflowRunsToReturn,
-	}).Info("Runs were returned ...")
+    log.WithFields(log.Fields{
+        "repo":         repo,
+        "owner":        owner,
+        "workflowFile": workflowFile,
+        "workflowRunsToReturn": workflowRunsToReturn,
+    }).Info("Runs were returned ...")
 
-	return runs.WorkflowRuns, nil
+    return runs.WorkflowRuns, nil
 
 }

--- a/gh/returnWorkflowRuns.go
+++ b/gh/returnWorkflowRuns.go
@@ -55,6 +55,18 @@ func ReturnWorkflowRuns(branchName string, ctx context.Context, client *github.C
         return nil, fmt.Errorf("API Method Gone")
     }
 
+    if res.StatusCode != 200 {
+
+        log.WithFields(log.Fields{
+            "Response Status":      res.StatusCode,
+            "repo":                 repo,
+            "owner":                owner,
+            "workflowFile":         workflowFile,
+            "workflowRunsToReturn": workflowRunsToReturn,
+        }).Warn("Request did not succeed: Response status received was not 200 ...")
+
+        return nil, fmt.Errorf("Response status received was not 200")
+    }
 
     if err != nil {
 

--- a/gh/returnWorkflowRuns_test.go
+++ b/gh/returnWorkflowRuns_test.go
@@ -95,7 +95,7 @@ func TestReturnWorkflowRuns(t *testing.T){
             wantErr:  nil,
         },
         {
-            name: "should fail with 404",
+            name: "should fail with code 404",
             args: args{
                 branch:          "ft/test-branch",
                 httpstatus:      404,
@@ -116,7 +116,7 @@ func TestReturnWorkflowRuns(t *testing.T){
             wantErr:  fmt.Errorf("Workflow not found"),
         },
         {
-            name: "should fail with 410",
+            name: "should fail with code 410",
             args: args{
                 branch:          "ft/test-branch",
                 httpstatus:      410,

--- a/gh/returnWorkflowRuns_test.go
+++ b/gh/returnWorkflowRuns_test.go
@@ -3,11 +3,15 @@ package gh
 import (
     "context"
     "fmt"
+    "io/ioutil"
     "net/http"
     "reflect"
     "testing"
     "time"
+
     "github.com/google/go-github/v47/github"
+    log "github.com/sirupsen/logrus"
+
 )
 
 func TestReturnWorkflowRuns(t *testing.T){
@@ -164,6 +168,9 @@ func TestReturnWorkflowRuns(t *testing.T){
         // var apiurl string
         
         t.Run(tt.name, func(t *testing.T) {
+
+            // supress logrus
+            log.SetOutput(ioutil.Discard)
 
             client, mux, _, teardown := Setup()
             defer teardown()

--- a/gh/returnWorkflowRuns_test.go
+++ b/gh/returnWorkflowRuns_test.go
@@ -176,14 +176,19 @@ func TestReturnWorkflowRuns(t *testing.T){
 
                 TestingMethod(t, r, "GET")
 
-                if tt.args.httpstatus == 200 {
-                    w.WriteHeader(http.StatusOK)
-                } else if tt.args.httpstatus == 404 {
-                    w.WriteHeader(http.StatusNotFound)
-                } else if tt.args.httpstatus == 410 {
-                    w.WriteHeader(http.StatusGone)
-                } else if tt.args.httpstatus == 504 {
-                    w.WriteHeader(http.StatusGatewayTimeout)
+                switch tt.args.httpstatus {
+
+                    case 200:
+                        w.WriteHeader(http.StatusOK)
+
+                    case 404:
+                        w.WriteHeader(http.StatusNotFound)
+
+                    case 410:
+                        w.WriteHeader(http.StatusGone)
+
+                    default:
+                        w.WriteHeader(http.StatusGatewayTimeout)
                 }
 
                 fmt.Fprint(w, tt.endpoint.runs)

--- a/gh/returnWorkflowRuns_test.go
+++ b/gh/returnWorkflowRuns_test.go
@@ -178,17 +178,17 @@ func TestReturnWorkflowRuns(t *testing.T){
 
                 switch tt.args.httpstatus {
 
-                    case 200:
-                        w.WriteHeader(http.StatusOK)
+                case 200:
+                    w.WriteHeader(http.StatusOK)
 
-                    case 404:
-                        w.WriteHeader(http.StatusNotFound)
+                case 404:
+                    w.WriteHeader(http.StatusNotFound)
 
-                    case 410:
-                        w.WriteHeader(http.StatusGone)
+                case 410:
+                    w.WriteHeader(http.StatusGone)
 
-                    default:
-                        w.WriteHeader(http.StatusGatewayTimeout)
+                default:
+                    w.WriteHeader(http.StatusGatewayTimeout)
                 }
 
                 fmt.Fprint(w, tt.endpoint.runs)

--- a/gh/returnWorkflowStatus.go
+++ b/gh/returnWorkflowStatus.go
@@ -4,9 +4,9 @@ import (
     "context"
     "fmt"
     "time"
-	
+
     "github.com/google/go-github/v47/github"
-	
+
     log "github.com/sirupsen/logrus"
 )
 
@@ -39,7 +39,7 @@ func ReturnWorkflowRunStatus(ctx context.Context, client *github.Client, owner s
             "owner":        owner,
             "workflowRunId": workflowRunId,
         }).Warn("received 410 code: API Method Gone...")
-		
+
         return "", &github.Timestamp{time.Time{}}, fmt.Errorf("API Method Gone")
     }
 

--- a/gh/returnWorkflowStatus.go
+++ b/gh/returnWorkflowStatus.go
@@ -43,6 +43,17 @@ func ReturnWorkflowRunStatus(ctx context.Context, client *github.Client, owner s
         return "", &github.Timestamp{time.Time{}}, fmt.Errorf("API Method Gone")
     }
 
+    if res.StatusCode != 200 {
+
+        log.WithFields(log.Fields{
+            "Response Status":      res.StatusCode,
+            "repo":         repo,
+            "owner":        owner,
+            "workflowRunId": workflowRunId,
+        }).Warn("Request did not succeed: Response status received was not 200 ...")
+
+        return "", &github.Timestamp{time.Time{}}, fmt.Errorf("Response status received was not 200")
+    }
 
     if err != nil {
 

--- a/gh/returnWorkflowStatus_test.go
+++ b/gh/returnWorkflowStatus_test.go
@@ -224,15 +224,20 @@ func TestReturnWorkflowRunStatustatus(t *testing.T){
 
                 TestingMethod(t, r, "GET")
 
-                if tt.args.httpstatus == 200 {
+                switch tt.args.httpstatus {
+
+                case 200:
                     w.WriteHeader(http.StatusOK)
-                } else if tt.args.httpstatus == 404 {
+
+                case 404:
                     w.WriteHeader(http.StatusNotFound)
-                } else if tt.args.httpstatus == 410 {
+
+                case 410:
                     w.WriteHeader(http.StatusGone)
-                } else if tt.args.httpstatus == 504 {
+
+                default:
                     w.WriteHeader(http.StatusGatewayTimeout)
-                }
+            }
 
                 fmt.Fprint(w, tt.endpoint.run)
             })

--- a/gh/returnWorkflowStatus_test.go
+++ b/gh/returnWorkflowStatus_test.go
@@ -3,15 +3,18 @@ package gh
 import (
     "context"
     "fmt"
+    "io/ioutil"
     "net/http"
     "reflect"
     "testing"
     "time"
 
     "github.com/google/go-github/v47/github"
+    log "github.com/sirupsen/logrus"
+
 )
 
-func TestReturnWorkflowRunStatustatus(t *testing.T){
+func TestReturnWorkflowRunStatus(t *testing.T){
 
     type endpoint struct{
         branch       string
@@ -212,6 +215,9 @@ func TestReturnWorkflowRunStatustatus(t *testing.T){
         // var apiurl string
         
         t.Run(tt.name, func(t *testing.T) {
+
+            // supress logrus
+            log.SetOutput(ioutil.Discard)
 
             client, mux, _, teardown := Setup()
             defer teardown()

--- a/gh/setup.go
+++ b/gh/setup.go
@@ -1,56 +1,56 @@
 package gh
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"os"
-	"testing"
-	"github.com/google/go-github/v47/github"
+    "fmt"
+    "net/http"
+    "net/http/httptest"
+    "net/url"
+    "os"
+    "testing"
+    "github.com/google/go-github/v47/github"
 )
 
 const (
-	// baseURLPath is a non-empty Client.BaseURL path to use during tests,
-	// to ensure relative URLs are used for all endpoints. See issue #752.
-	baseURLPath = "/api-v3"
+    // baseURLPath is a non-empty Client.BaseURL path to use during tests,
+    // to ensure relative URLs are used for all endpoints. See issue #752.
+    baseURLPath = "/api-v3"
 )
 
 func TestingMethod(t *testing.T, r *http.Request, want string) {
-	t.Helper()
-	if got := r.Method; got != want {
-		t.Errorf("Request method: %v, want %v", got, want)
-	}
+    t.Helper()
+    if got := r.Method; got != want {
+        t.Errorf("Request method: %v, want %v", got, want)
+    }
 }
 
 func Setup() (client *github.Client, mux *http.ServeMux, serverURL string, teardown func()) {
-	// mux is the HTTP request multiplexer used with the test server.
-	mux = http.NewServeMux()
+    // mux is the HTTP request multiplexer used with the test server.
+    mux = http.NewServeMux()
 
-	// We want to ensure that tests catch mistakes where the endpoint URL is
-	// specified as absolute rather than relative. It only makes a difference
-	// when there's a non-empty base URL path. So, use that. See issue #752.
-	apiHandler := http.NewServeMux()
-	apiHandler.Handle(baseURLPath+"/", http.StripPrefix(baseURLPath, mux))
-	apiHandler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-		fmt.Fprintln(os.Stderr, "FAIL: Client.BaseURL path prefix is not preserved in the request URL:")
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "\tDid you accidentally use an absolute endpoint URL rather than relative?")
-		fmt.Fprintln(os.Stderr, "\tSee https://github.com/google/go-github/issues/752 for information.")
-		http.Error(w, "Client.BaseURL path prefix is not preserved in the request URL.", http.StatusInternalServerError)
-	})
+    // We want to ensure that tests catch mistakes where the endpoint URL is
+    // specified as absolute rather than relative. It only makes a difference
+    // when there's a non-empty base URL path. So, use that. See issue #752.
+    apiHandler := http.NewServeMux()
+    apiHandler.Handle(baseURLPath+"/", http.StripPrefix(baseURLPath, mux))
+    apiHandler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+        fmt.Fprintln(os.Stderr, "FAIL: Client.BaseURL path prefix is not preserved in the request URL:")
+        fmt.Fprintln(os.Stderr)
+        fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
+        fmt.Fprintln(os.Stderr)
+        fmt.Fprintln(os.Stderr, "\tDid you accidentally use an absolute endpoint URL rather than relative?")
+        fmt.Fprintln(os.Stderr, "\tSee https://github.com/google/go-github/issues/752 for information.")
+        http.Error(w, "Client.BaseURL path prefix is not preserved in the request URL.", http.StatusInternalServerError)
+    })
 
-	// server is a test HTTP server used to provide mock API responses.
-	server := httptest.NewServer(apiHandler)
+    // server is a test HTTP server used to provide mock API responses.
+    server := httptest.NewServer(apiHandler)
 
-	// client is the GitHub client being tested and is
-	// configured to use test server.
-	client = github.NewClient(nil)
-	url, _ := url.Parse(server.URL + baseURLPath + "/")
-	client.BaseURL = url
-	client.UploadURL = url
+    // client is the GitHub client being tested and is
+    // configured to use test server.
+    client = github.NewClient(nil)
+    url, _ := url.Parse(server.URL + baseURLPath + "/")
+    client.BaseURL = url
+    client.UploadURL = url
 
-	return client, mux, server.URL, server.Close
+    return client, mux, server.URL, server.Close
 }

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main(){
         // get whether 3 parameters - to be used in the nex mode:
         shouldRunExecute, shouldWaitForPastRun, pastRunIdStr,  ShouldExecuteErr := util.ShouldExecute(runs, *runNumber)
 
+       // panic - crash hard if ShouldExectue errored out:
        if ShouldExecuteErr != nil {
             log.WithFields(log.Fields{
                 "repo":         *repo,
@@ -56,6 +57,9 @@ func main(){
                 "workflowFile": *workflowFile,
                 "workflowRunsToReturn": *workflowRunsToReturn,
             }).Error(ShouldExecuteErr.Error())
+
+            panic(fmt.Sprintf("Failed to complete 'shouldExecute' mode with error %s", ShouldExecuteErr.Error()))
+
         }
 
         // export variables retrieved from ShouldExecute() to the environment:

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main(){
         }
 
         // get whether 3 parameters - to be used in the nex mode:
-        shouldRunExecute, shouldWaitForPastRun, pastRunIdStr,  ShouldExecuteErr := util.ShouldExecute(runs, *runNumber)
+        shouldRunExecute, shouldWaitForPastRun, pastRunIdStr,  ShouldExecuteErr := util.ShouldExecute(runs, *runNumber, int(*workflowRunsToReturn))
 
        // panic - crash hard if ShouldExectue errored out:
        if ShouldExecuteErr != nil {

--- a/main.go
+++ b/main.go
@@ -3,10 +3,10 @@ package main
 import (
     "flag"
     "fmt"
-	"time"
+    "time"
 
     util "gh-actions-workflow-runs-sorter/util"
-	gh "gh-actions-workflow-runs-sorter/gh"
+    gh "gh-actions-workflow-runs-sorter/gh"
 
     log "github.com/sirupsen/logrus"
 )
@@ -14,16 +14,16 @@ import (
 
 func main(){
 
-	branch               := flag.String("branch", "main", "git branch name")
-	mode                 := flag.String("run-mode", "shouldExecute", "which run mode to run - options available are 'shouldExecute' or 'shouldComplete'")
-	owner                := flag.String("owner", "sarmad-abualkaz", "owner of github repo")
-	repo                 := flag.String("repo", "test-repo", "github repoistory name")
-	runNumber            := flag.Int("run_number", 0, "unique number for each run of a particular workflow in a repository")
-	previousRunId        := flag.Int("prev_run_number", 0, "unique number for the previous run of a particular workflow in a repository")
-	workflowFile         := flag.String("workflowFile", "cron_and_dispatch.yml", "workflow to link users to")
-	workflowRunsToReturn := flag.Int("workflow_run_to_return", 20, "number of workflow runs to return")
-	waitBetweenChecks    := flag.Int("wait_between_checks", 10, "how long, in seconds, to wait between checks on previous workflow run")
-        waitBeforeComplete   := flag.Float64("wait_before_complete", 60, "how long, in seconds, to wait after a completed previous workflow run")
+    branch               := flag.String("branch", "main", "git branch name")
+    mode                 := flag.String("run-mode", "shouldExecute", "which run mode to run - options available are 'shouldExecute' or 'shouldComplete'")
+    owner                := flag.String("owner", "sarmad-abualkaz", "owner of github repo")
+    repo                 := flag.String("repo", "test-repo", "github repoistory name")
+    runNumber            := flag.Int("run_number", 0, "unique number for each run of a particular workflow in a repository")
+    previousRunId        := flag.Int("prev_run_number", 0, "unique number for the previous run of a particular workflow in a repository")
+    workflowFile         := flag.String("workflowFile", "cron_and_dispatch.yml", "workflow to link users to")
+    workflowRunsToReturn := flag.Int("workflow_run_to_return", 20, "number of workflow runs to return")
+    waitBetweenChecks    := flag.Int("wait_between_checks", 10, "how long, in seconds, to wait between checks on previous workflow run")
+    waitBeforeComplete   := flag.Float64("wait_before_complete", 60, "how long, in seconds, to wait after a completed previous workflow run")
 
     flag.Parse()
 
@@ -34,7 +34,7 @@ func main(){
     // mode is to check should the workflow execute
     if *mode == "shouldExecute" {
 
-		// get last x number of workflow runs to return (x = workflowRunsToReturn)
+        // get last x number of workflow runs to return (x = workflowRunsToReturn)
         runs, ghErr := gh.ReturnWorkflowRuns(*branch, ctx, client, *owner, *repo, *workflowFile, int(*workflowRunsToReturn))
 
         if ghErr != nil {
@@ -47,9 +47,9 @@ func main(){
         }
 
         // get whether 3 parameters - to be used in the nex mode:
-		shouldRunExecute, shouldWaitForPastRun, pastRunIdStr,  ShouldExecuteErr := util.ShouldExecute(runs, *runNumber)
+        shouldRunExecute, shouldWaitForPastRun, pastRunIdStr,  ShouldExecuteErr := util.ShouldExecute(runs, *runNumber)
 
-		if ShouldExecuteErr != nil {
+       if ShouldExecuteErr != nil {
             log.WithFields(log.Fields{
                 "repo":         *repo,
                 "owner":        *owner,
@@ -59,20 +59,20 @@ func main(){
         }
 
         // export variables retrieved from ShouldExecute() to the environment:
-		fmt.Printf("export SHOULD_RUN_EXECUTE=%s\n", shouldRunExecute)
-		fmt.Printf("export SHOULD_WAIT_FOR_PAST_RUN=%s\n", shouldWaitForPastRun)
-		fmt.Printf("export PAST_RUN_ID=%s\n", pastRunIdStr)
+        fmt.Printf("export SHOULD_RUN_EXECUTE=%s\n", shouldRunExecute)
+        fmt.Printf("export SHOULD_WAIT_FOR_PAST_RUN=%s\n", shouldWaitForPastRun)
+        fmt.Printf("export PAST_RUN_ID=%s\n", pastRunIdStr)
 
     // check if worklflow should complete:
-	} else if *mode == "shouldComplete" {
+    } else if *mode == "shouldComplete" {
 
         // continously loop if status on a previous workflow run is not "completed"
-		for {
+        for {
             
             // retrieve details on last workflow run - status and update_time:
-			lastRunStatus, lastRunUpdateTime, ReturnWorkflowRunStatusErr := gh.ReturnWorkflowRunStatus(ctx, client, *owner, *repo, int(*previousRunId))
+            lastRunStatus, lastRunUpdateTime, ReturnWorkflowRunStatusErr := gh.ReturnWorkflowRunStatus(ctx, client, *owner, *repo, int(*previousRunId))
 
-			if ReturnWorkflowRunStatusErr != nil {
+            if ReturnWorkflowRunStatusErr != nil {
 
                 log.WithFields(log.Fields{
                     "repo":         *repo,
@@ -83,7 +83,7 @@ func main(){
             }
 
             // sleep if status on last workflow run is not "completed"
-			if lastRunStatus != "completed" {
+            if lastRunStatus != "completed" {
 
                 log.WithFields(log.Fields{
                     "repo":             *repo,
@@ -96,7 +96,7 @@ func main(){
             	time.Sleep(time.Duration(*waitBetweenChecks)*time.Second)
 
             // if status is "completed" check if the update_time on last workflow passed provided wait_before_complete
-			} else {
+            } else {
                 
                 // loop until current_time - update_time is less than wait_before_complete
                 for {
@@ -140,13 +140,13 @@ func main(){
 
                 // break the main loop
                 break
-			}
+            }
 
-		}
+        }
     
     // panic if run_mode is neither shouldExecute or shouldComplete
-	} else {
-		panic(fmt.Sprintf("mode passed is %s - allowed values are shouldExecute or shouldComplete", *mode))
-	}
+    } else {
+        panic(fmt.Sprintf("mode passed is %s - allowed values are shouldExecute or shouldComplete", *mode))
+    }
 
 }

--- a/util/shouldComplete.go
+++ b/util/shouldComplete.go
@@ -3,8 +3,8 @@ package util
 func ShouldComplete(previousRunStatus string) bool {
 
     if previousRunStatus != "completed" {
-		return false
-	}
+       return false
+    }
 
-	return true
+    return true
 }

--- a/util/shouldComplete_test.go
+++ b/util/shouldComplete_test.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"reflect"
+    "reflect"
     "testing"
 )
 

--- a/util/shouldComplete_test.go
+++ b/util/shouldComplete_test.go
@@ -32,13 +32,17 @@ func TestShouldComplete(t *testing.T){
 
     for _, tt := range tests {
 
-        gotShouldComplete := ShouldComplete(tt.previousRunStatus)
+        t.Run(tt.name, func(t *testing.T) {
 
-        if !reflect.DeepEqual(gotShouldComplete, tt.wantShouldComplete){
-            
-            t.Errorf("ShouldComplete() failed - ID expects %t but received %t", tt.wantShouldComplete, gotShouldComplete)
+            gotShouldComplete := ShouldComplete(tt.previousRunStatus)
 
-        }
+            if !reflect.DeepEqual(gotShouldComplete, tt.wantShouldComplete){
+
+                t.Errorf("ShouldComplete() failed - ID expects %t but received %t", tt.wantShouldComplete, gotShouldComplete)
+
+            }
+
+        })
     }
 
 }

--- a/util/shouldExecute.go
+++ b/util/shouldExecute.go
@@ -8,7 +8,7 @@ import (
     log "github.com/sirupsen/logrus"
 )
 
-func ShouldExecute(runs []*github.WorkflowRun, runNumber int)(string, string, string, error){
+func ShouldExecute(runs []*github.WorkflowRun, runNumber int, workflowRunsToReturn int)(string, string, string, error){
 
     /*
 
@@ -85,11 +85,11 @@ func ShouldExecute(runs []*github.WorkflowRun, runNumber int)(string, string, st
     case runs_length < 1:
         return shouldRunExecute, shouldWaitForPastRun, pastRunIdStr, fmt.Errorf("No previous runs were returned from Github Actions API")
 
-    case runs_length < 20:
+    case runs_length < workflowRunsToReturn:
         log.WithFields(log.Fields{
             "runNumber":               runNumber,
             "number of previous runs": len(runs),
-        }).Warn(fmt.Sprintf("Number of workflow runs recieved from API is less than 20."))
+        }).Warn(fmt.Sprintf("Number of workflow runs recieved from API is less than %d.", workflowRunsToReturn))
     }
 
     log.WithFields(log.Fields{

--- a/util/shouldExecute.go
+++ b/util/shouldExecute.go
@@ -1,81 +1,81 @@
 package util
 
 import (
-	"fmt"
-	"strconv"
-	
-	"github.com/google/go-github/v47/github"
-	log "github.com/sirupsen/logrus"
+    "fmt"
+    "strconv"
+
+    "github.com/google/go-github/v47/github"
+    log "github.com/sirupsen/logrus"
 )
 
 func ShouldExecute(runs []*github.WorkflowRun, runNumber int)(string, string, string, error){
 
-	/*
+    /*
 
-	sudo-code logic:
+    sudo-code logic:
 
-	> should it pubish?
+    > should it pubish?
 	
-	- if no (latest completed/successful run has a higher run_number)
+    - if no (latest completed/successful run has a higher run_number)
 
-	- if yes
-		> should it wait - prev run_number is in progress?
-	*/
+    - if yes
+        > should it wait - prev run_number is in progress?
+    */
 
-	// currentRunNumber, err := strconv.Atoi(runNumber)
+    // currentRunNumber, err := strconv.Atoi(runNumber)
 
-	// if err != nil {
+    // if err != nil {
 	
-	// 	return "", "", "", err
+    // 	return "", "", "", err
 
-	// }
+    // }
 
-	// set the execution run requirement to false by default
-	shouldRunExecute := "false"
-	shouldWaitForPastRun := "false"
-	pastRunId := int64(0)
+    // set the execution run requirement to false by default
+    shouldRunExecute := "false"
+    shouldWaitForPastRun := "false"
+    pastRunId := int64(0)
 	
-	// loop through each run from this workflow:
-	for _, run := range runs {
+    // loop through each run from this workflow:
+    for _, run := range runs {
 
-		// latest completed/successful run has a higher run_number:
-		if (*run.RunNumber > runNumber) && (*run.Status == "completed") {
+        // latest completed/successful run has a higher run_number:
+        if (*run.RunNumber > runNumber) && (*run.Status == "completed") {
 
-			log.WithFields(log.Fields{
-				"runNumber": runNumber,
-			}).Warn(fmt.Sprintf("There's no need to re-run this workflow run; latest 'future' workflow run has completed with id %d\n", *run.RunNumber))
-			
-			// do not update the shouldRunExecute, shouldWaitForPastRun or pastRunId
-			// break loop - the rest of the logic is not required
-			break
-		
-		// found the first previous run with a complete status:
-		} else if (*run.RunNumber < runNumber) && (*run.Status == "completed") {
-			
-			// do not update shouldWaitForPastRun - fine as false
-			// update shouldRunExecute and pastRunId
-			shouldRunExecute = "true"
-			pastRunId = *run.ID
-			break
+            log.WithFields(log.Fields{
+                "runNumber": runNumber,
+            }).Warn(fmt.Sprintf("There's no need to re-run this workflow run; latest 'future' workflow run has completed with id %d\n", *run.RunNumber))
 
-		} else if (*run.RunNumber < runNumber) && (*run.Status != "completed") {
+            // do not update the shouldRunExecute, shouldWaitForPastRun or pastRunId
+            // break loop - the rest of the logic is not required
+            break
 
-			// update shouldRunExecute, shouldWaitForPastRun and pastRunId
-			shouldRunExecute = "true"
-			shouldWaitForPastRun = "true"
-			pastRunId = *run.ID
-			break
-		}
-	}
+        // found the first previous run with a complete status:
+        } else if (*run.RunNumber < runNumber) && (*run.Status == "completed") {
 
-	// convert to string from pastRunId
-	pastRunIdStr := strconv.Itoa(int(pastRunId))
+            // do not update shouldWaitForPastRun - fine as false
+            // update shouldRunExecute and pastRunId
+            shouldRunExecute = "true"
+            pastRunId = *run.ID
+            break
 
-	log.WithFields(log.Fields{
-		"runNumber": runNumber,
-	}).Info(fmt.Sprintf("updating data with SHOULD_RUN_EXECUTE = %s; SHOULD_WAIT_FOR_PAST_RUN = %s; PAST_RUN_ID = %s\n", shouldRunExecute, shouldWaitForPastRun, pastRunIdStr))
+        } else if (*run.RunNumber < runNumber) && (*run.Status != "completed") {
 
-	return shouldRunExecute, shouldWaitForPastRun, pastRunIdStr, nil
+            // update shouldRunExecute, shouldWaitForPastRun and pastRunId
+            shouldRunExecute = "true"
+            shouldWaitForPastRun = "true"
+            pastRunId = *run.ID
+            break
+        }
+    }
+
+    // convert to string from pastRunId
+    pastRunIdStr := strconv.Itoa(int(pastRunId))
+
+    log.WithFields(log.Fields{
+        "runNumber": runNumber,
+    }).Info(fmt.Sprintf("updating data with SHOULD_RUN_EXECUTE = %s; SHOULD_WAIT_FOR_PAST_RUN = %s; PAST_RUN_ID = %s\n", shouldRunExecute, shouldWaitForPastRun, pastRunIdStr))
+
+    return shouldRunExecute, shouldWaitForPastRun, pastRunIdStr, nil
 }
 
 /*
@@ -83,19 +83,19 @@ sudo-code logic:
 
 > should it pubish?
 	
-	- if no (latest completed/successful run has a higher run_number)
+    - if no (latest completed/successful run has a higher run_number)
 
-	- if yes
-		> should it wait - prev run_number is in progress?
-			
-			- if yes
-				> At the end shoud it complete?
-					
-					- if yes (prev run_number is completed - success/failed):
-						> sleep x seconds for post success-complete of prev
-						or
-						> don't sleep if prev run_number failed
-					
-					- if no
-						> sleep x seconds - waiting for previous run to complete
+    - if yes
+        > should it wait - prev run_number is in progress?
+
+            - if yes
+                > At the end shoud it complete?
+
+                    - if yes (prev run_number is completed - success/failed):
+                        > sleep x seconds for post success-complete of prev
+                        or
+                        > don't sleep if prev run_number failed
+
+                    - if no
+                        > sleep x seconds - waiting for previous run to complete
 */

--- a/util/shouldExecute_test.go
+++ b/util/shouldExecute_test.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"reflect"
+    "reflect"
     "testing"
     "time"
 

--- a/util/shouldExecute_test.go
+++ b/util/shouldExecute_test.go
@@ -2,11 +2,14 @@ package util
 
 import (
     "fmt"
+    "io/ioutil"
     "reflect"
     "testing"
     "time"
 
     "github.com/google/go-github/v47/github"
+    log "github.com/sirupsen/logrus"
+
 )
 
 func TestShouldExecute(t *testing.T){
@@ -33,6 +36,7 @@ func TestShouldExecute(t *testing.T){
             wantShouldWaitForPastRun: "false",
             wantPastRunId: "0",
             wantError: nil,
+            workflowRunsToReturn: 4,
         },
         {
             name: "should execute but not wait",
@@ -47,7 +51,7 @@ func TestShouldExecute(t *testing.T){
             wantShouldWaitForPastRun: "false",
             wantPastRunId: "3333333333",
             wantError: nil,
-            workflowRunsToReturn: 20,
+            workflowRunsToReturn: 4,
         },        
         {
             name: "should execute and wait",
@@ -62,7 +66,7 @@ func TestShouldExecute(t *testing.T){
             wantShouldWaitForPastRun: "true",
             wantPastRunId: "3333333333",
             wantError: nil,
-            workflowRunsToReturn: 30,       
+            workflowRunsToReturn: 4,
         },
         {
             name: "should return error - zero runs",
@@ -79,36 +83,43 @@ func TestShouldExecute(t *testing.T){
 
     for _, tt := range tests {
 
-        gotShouldExecute, gotShouldWaitForPastRun, gotPastRunId, gotError := ShouldExecute(tt.runs, tt.runNumber, tt.workflowRunsToReturn)
+        t.Run(tt.name, func(t *testing.T) {
 
-        if tt.wantError == nil {
-                
-            if gotError != nil {
+            // supress logrus
+            log.SetOutput(ioutil.Discard)
+
+            gotShouldExecute, gotShouldWaitForPastRun, gotPastRunId, gotError := ShouldExecute(tt.runs, tt.runNumber, tt.workflowRunsToReturn)
+
+            if tt.wantError == nil {
+
+                if gotError != nil {
+                    t.Errorf("ShouldExecute() returned error: '%v' expect '%v'", gotError, tt.wantError)
+                }
+
+            } else if gotError.Error() != tt.wantError.Error() {
+
                 t.Errorf("ShouldExecute() returned error: '%v' expect '%v'", gotError, tt.wantError)
             }
 
-        } else if gotError.Error() != tt.wantError.Error() {
-            
-            t.Errorf("ShouldExecute() returned error: '%v' expect '%v'", gotError, tt.wantError)
-        }
+            if !reflect.DeepEqual(tt.wantShouldExecute, gotShouldExecute){
 
-        if !reflect.DeepEqual(tt.wantShouldExecute, gotShouldExecute){
-            
-            t.Errorf("ShouldExecute() failed - shouldExecute? expects '%s' but received '%s'", tt.wantShouldExecute, gotShouldExecute)
+                t.Errorf("ShouldExecute() failed - shouldExecute? expects '%s' but received '%s'", tt.wantShouldExecute, gotShouldExecute)
 
-        }
+            }
 
-        if !reflect.DeepEqual(tt.wantShouldWaitForPastRun, gotShouldWaitForPastRun){
-            
-            t.Errorf("ShouldExecute() failed - shouldWaitForPastRun? expects '%s' but received '%s'", tt.wantShouldWaitForPastRun, gotShouldWaitForPastRun)
+            if !reflect.DeepEqual(tt.wantShouldWaitForPastRun, gotShouldWaitForPastRun){
 
-        }
+                t.Errorf("ShouldExecute() failed - shouldWaitForPastRun? expects '%s' but received '%s'", tt.wantShouldWaitForPastRun, gotShouldWaitForPastRun)
 
-        if !reflect.DeepEqual(tt.wantPastRunId, gotPastRunId){
-            
-            t.Errorf("ShouldExecute() failed - pastRunId expects '%s' but received '%s'", tt.wantPastRunId, gotPastRunId)
+            }
 
-        }
+            if !reflect.DeepEqual(tt.wantPastRunId, gotPastRunId){
+
+                t.Errorf("ShouldExecute() failed - pastRunId expects '%s' but received '%s'", tt.wantPastRunId, gotPastRunId)
+
+            }
+
+        })
     }
 
 }

--- a/util/shouldExecute_test.go
+++ b/util/shouldExecute_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+    "fmt"
     "reflect"
     "testing"
     "time"
@@ -60,6 +61,15 @@ func TestShouldExecute(t *testing.T){
             wantPastRunId: "3333333333",
             wantError: nil,        
         },
+        {
+            name: "should return error - zero runs",
+            runs: []*github.WorkflowRun{},
+            runNumber: 31,
+            wantShouldExecute: "false",
+            wantShouldWaitForPastRun: "false",
+            wantPastRunId: "0",
+            wantError: fmt.Errorf("No previous runs were returned from Github Actions API"),
+        },
 
     }
 
@@ -70,29 +80,29 @@ func TestShouldExecute(t *testing.T){
         if tt.wantError == nil {
                 
             if gotError != nil {
-                t.Errorf("ShouldExecute() returned error: %v expect %v", gotError, tt.wantError)
+                t.Errorf("ShouldExecute() returned error: '%v' expect '%v'", gotError, tt.wantError)
             }
 
         } else if gotError.Error() != tt.wantError.Error() {
             
-            t.Errorf("ShouldExecute() returned error: %v expect %v", gotError, tt.wantError)
+            t.Errorf("ShouldExecute() returned error: '%v' expect '%v'", gotError, tt.wantError)
         }
 
         if !reflect.DeepEqual(tt.wantShouldExecute, gotShouldExecute){
             
-            t.Errorf("ShouldExecute() failed - shouldExecute? expects %s but received %s", tt.wantShouldExecute, gotShouldExecute)
+            t.Errorf("ShouldExecute() failed - shouldExecute? expects '%s' but received '%s'", tt.wantShouldExecute, gotShouldExecute)
 
         }
 
         if !reflect.DeepEqual(tt.wantShouldWaitForPastRun, gotShouldWaitForPastRun){
             
-            t.Errorf("ShouldExecute() failed - shouldWaitForPastRun? expects %s but received %s", tt.wantShouldWaitForPastRun, gotShouldWaitForPastRun)
+            t.Errorf("ShouldExecute() failed - shouldWaitForPastRun? expects '%s' but received '%s'", tt.wantShouldWaitForPastRun, gotShouldWaitForPastRun)
 
         }
 
         if !reflect.DeepEqual(tt.wantPastRunId, gotPastRunId){
             
-            t.Errorf("ShouldExecute() failed - pastRunId expects %s but received %s", tt.wantPastRunId, gotPastRunId)
+            t.Errorf("ShouldExecute() failed - pastRunId expects '%s' but received '%s'", tt.wantPastRunId, gotPastRunId)
 
         }
     }

--- a/util/shouldExecute_test.go
+++ b/util/shouldExecute_test.go
@@ -19,6 +19,7 @@ func TestShouldExecute(t *testing.T){
         wantShouldWaitForPastRun string
         wantPastRunId            string
         wantError                error
+        workflowRunsToReturn     int
     }{
         {
             name: "should not execute",
@@ -46,6 +47,7 @@ func TestShouldExecute(t *testing.T){
             wantShouldWaitForPastRun: "false",
             wantPastRunId: "3333333333",
             wantError: nil,
+            workflowRunsToReturn: 20,
         },        
         {
             name: "should execute and wait",
@@ -59,7 +61,8 @@ func TestShouldExecute(t *testing.T){
             wantShouldExecute: "true",
             wantShouldWaitForPastRun: "true",
             wantPastRunId: "3333333333",
-            wantError: nil,        
+            wantError: nil,
+            workflowRunsToReturn: 30,       
         },
         {
             name: "should return error - zero runs",
@@ -69,13 +72,14 @@ func TestShouldExecute(t *testing.T){
             wantShouldWaitForPastRun: "false",
             wantPastRunId: "0",
             wantError: fmt.Errorf("No previous runs were returned from Github Actions API"),
+            workflowRunsToReturn: 20,
         },
 
     }
 
     for _, tt := range tests {
 
-        gotShouldExecute, gotShouldWaitForPastRun, gotPastRunId, gotError := ShouldExecute(tt.runs, tt.runNumber)
+        gotShouldExecute, gotShouldWaitForPastRun, gotPastRunId, gotError := ShouldExecute(tt.runs, tt.runNumber, tt.workflowRunsToReturn)
 
         if tt.wantError == nil {
                 


### PR DESCRIPTION
This PR includes:
- handling non 200 responses from GH Actions APIs (with tests for this new logic).
- handling when `len(runs)` or length of total workflow runs returned from GH Actions APIs is less than `workflowRunsToReturn` (workflowRunsToReturn, given that we ask to have a minimum of [workflowRunsToReturn](https://github.com/untitledstartup/gh-actions-workflow-runs-sorter/blob/main/main.go#L24) per page and take the [first page](https://github.com/untitledstartup/gh-actions-workflow-runs-sorter/blob/main/gh/returnWorkflowRuns.go#L24-L25)) - **this will log a Warn**.
- Handling when `len(runs)` or length of total workflow runs returned from GH Actions APIs is zero - **this will return an error** .
- Handling when `shouldExecute` function returns an error - main func will panic since this does not have any proper results to return.
- Make indentation consistent across the project.
- Suppress logurs logs during tests 