### PR TITLE
Retry GitHub API calls on transport errors and 5xx responses

### DIFF
--- a/gh/retry.go
+++ b/gh/retry.go
@@ -1,0 +1,26 @@
+package gh
+
+import (
+    "time"
+
+    "github.com/google/go-github/v47/github"
+)
+
+const maxAttempts = 3
+
+// sleepBetweenRetries is a variable so tests can eliminate the backoff delay.
+var sleepBetweenRetries = func(attempt int) {
+    time.Sleep(time.Duration(attempt) * 5 * time.Second)
+}
+
+// retryableAPIFailure reports whether a GitHub API call failed in a way worth
+// retrying: a transport error (no HTTP response at all) or a 5xx from the API.
+// 4xx responses (404, 410, auth) are permanent and must not be retried.
+func retryableAPIFailure(res *github.Response, err error) bool {
+
+    if res == nil {
+        return err != nil
+    }
+
+    return res.StatusCode >= 500
+}

--- a/gh/retry.go
+++ b/gh/retry.go
@@ -1,6 +1,8 @@
 package gh
 
 import (
+    "context"
+    "errors"
     "time"
 
     "github.com/google/go-github/v47/github"
@@ -8,15 +10,29 @@ import (
 
 const maxAttempts = 3
 
-// sleepBetweenRetries is a variable so tests can eliminate the backoff delay.
-var sleepBetweenRetries = func(attempt int) {
-    time.Sleep(time.Duration(attempt) * 5 * time.Second)
+// sleepBetweenRetries waits attempt*5s before the next retry, returning early
+// if ctx is canceled or its deadline passes so a canceled call does not block
+// through the backoff. It is a variable so tests can eliminate the delay.
+var sleepBetweenRetries = func(ctx context.Context, attempt int) {
+
+    timer := time.NewTimer(time.Duration(attempt) * 5 * time.Second)
+    defer timer.Stop()
+
+    select {
+    case <-timer.C:
+    case <-ctx.Done():
+    }
 }
 
 // retryableAPIFailure reports whether a GitHub API call failed in a way worth
 // retrying: a transport error (no HTTP response at all) or a 5xx from the API.
-// 4xx responses (404, 410, auth) are permanent and must not be retried.
+// 4xx responses (404, 410, auth) are permanent, and context cancellation or
+// deadline errors are terminal — neither is ever retried.
 func retryableAPIFailure(res *github.Response, err error) bool {
+
+    if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+        return false
+    }
 
     if res == nil {
         return err != nil

--- a/gh/retry_test.go
+++ b/gh/retry_test.go
@@ -1,0 +1,77 @@
+package gh
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "testing"
+
+    "github.com/google/go-github/v47/github"
+    log "github.com/sirupsen/logrus"
+)
+
+func TestRetryableAPIFailure(t *testing.T) {
+
+    tests := []struct {
+        name string
+        res  *github.Response
+        err  error
+        want bool
+    }{
+        {"transport error, no response", nil, fmt.Errorf("connection reset by peer"), true},
+        {"5xx response", &github.Response{Response: &http.Response{StatusCode: 503}}, nil, true},
+        {"4xx response", &github.Response{Response: &http.Response{StatusCode: 404}}, nil, false},
+        {"200 response", &github.Response{Response: &http.Response{StatusCode: 200}}, nil, false},
+        {"bare context canceled", nil, context.Canceled, false},
+        {"bare deadline exceeded", nil, context.DeadlineExceeded, false},
+        {"wrapped context canceled", nil, fmt.Errorf("Get \"...\": %w", context.Canceled), false},
+        {"wrapped deadline exceeded", nil, fmt.Errorf("Get \"...\": %w", context.DeadlineExceeded), false},
+        {"no response, no error", nil, nil, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            if got := retryableAPIFailure(tt.res, tt.err); got != tt.want {
+                t.Errorf("retryableAPIFailure() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+
+// A canceled context must fail fast: the wrapper should not classify the
+// resulting transport error as retryable, so it never enters the backoff.
+func TestReturnWorkflowRunsDoesNotRetryOnCanceledContext(t *testing.T) {
+
+    // supress logrus
+    log.SetOutput(ioutil.Discard)
+
+    sleeps := 0
+    sleepBetweenRetries = func(context.Context, int) { sleeps++ }
+
+    client, mux, _, teardown := Setup()
+    defer teardown()
+
+    mux.HandleFunc("/repos/testowner/testrepo/actions/workflows/testfile.yaml/runs", func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+        fmt.Fprint(w, `{"total_count":0,"workflow_runs":[]}`)
+    })
+
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel()
+
+    _, gotErr := ReturnWorkflowRuns("ft/test-branch", ctx, client, "testowner", "testrepo", "testfile.yaml", 20)
+
+    if gotErr == nil {
+        t.Fatalf("expected an error on a canceled context but got nil")
+    }
+
+    if !errors.Is(gotErr, context.Canceled) {
+        t.Errorf("expected context.Canceled but got '%v'", gotErr)
+    }
+
+    if sleeps != 0 {
+        t.Errorf("expected no backoff sleeps on a canceled context but got %d", sleeps)
+    }
+}

--- a/gh/returnWorkflowRuns.go
+++ b/gh/returnWorkflowRuns.go
@@ -49,7 +49,7 @@ func ReturnWorkflowRuns(branchName string, ctx context.Context, client *github.C
         }).Warn("Transient GitHub API failure listing workflow runs ...")
 
         if attempt < maxAttempts {
-            sleepBetweenRetries(attempt)
+            sleepBetweenRetries(ctx, attempt)
         }
     }
 

--- a/gh/returnWorkflowRuns.go
+++ b/gh/returnWorkflowRuns.go
@@ -26,7 +26,37 @@ func ReturnWorkflowRuns(branchName string, ctx context.Context, client *github.C
         },
     }
 
-    runs, res, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowFile, opts)
+    var runs *github.WorkflowRuns
+    var res *github.Response
+    var err error
+
+    // Retry transient failures (transport errors, 5xx) — a single GitHub API
+    // blip here otherwise aborts the whole shouldExecute decision.
+    for attempt := 1; attempt <= maxAttempts; attempt++ {
+
+        runs, res, err = client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowFile, opts)
+
+        if !retryableAPIFailure(res, err) {
+            break
+        }
+
+        log.WithFields(log.Fields{
+            "attempt":      attempt,
+            "maxAttempts":  maxAttempts,
+            "repo":         repo,
+            "owner":        owner,
+            "workflowFile": workflowFile,
+        }).Warn("Transient GitHub API failure listing workflow runs ...")
+
+        if attempt < maxAttempts {
+            sleepBetweenRetries(attempt)
+        }
+    }
+
+    // transport error on every attempt — no HTTP response to inspect
+    if res == nil {
+        return nil, err
+    }
 
     if res.StatusCode == 404 {
 

--- a/gh/returnWorkflowRuns_test.go
+++ b/gh/returnWorkflowRuns_test.go
@@ -172,6 +172,9 @@ func TestReturnWorkflowRuns(t *testing.T){
             // supress logrus
             log.SetOutput(ioutil.Discard)
 
+            // no backoff delay in tests
+            sleepBetweenRetries = func(int) {}
+
             client, mux, _, teardown := Setup()
             defer teardown()
 
@@ -269,3 +272,140 @@ func TestReturnWorkflowRuns(t *testing.T){
     }
 
 }
+
+
+func TestReturnWorkflowRunsRetriesOn5xx(t *testing.T) {
+
+    // supress logrus
+    log.SetOutput(ioutil.Discard)
+
+    // no backoff delay in tests
+    sleepBetweenRetries = func(int) {}
+
+    client, mux, _, teardown := Setup()
+    defer teardown()
+
+    ctx := context.Background()
+
+    calls := 0
+
+    mux.HandleFunc("/repos/testowner/testrepo/actions/workflows/testfile.yaml/runs", func(w http.ResponseWriter, r *http.Request) {
+
+        TestingMethod(t, r, "GET")
+
+        calls++
+
+        // fail with 503 twice, then succeed
+        if calls < 3 {
+            w.WriteHeader(http.StatusServiceUnavailable)
+            fmt.Fprint(w, `{}`)
+            return
+        }
+
+        w.WriteHeader(http.StatusOK)
+        fmt.Fprint(w, `{"total_count":1,"workflow_runs":[
+            {
+                "id": 1111111111,
+                "name": "Test Workflow",
+                "node_id": "fakenode01",
+                "run_number": 1,
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2022-12-12T21:34:57Z",
+                "updated_at": "2022-12-12T21:47:06Z"
+            }
+        ]}`)
+    })
+
+    gotRuns, gotErr := ReturnWorkflowRuns("ft/test-branch", ctx, client, "testowner", "testrepo", "testfile.yaml", 20)
+
+    if gotErr != nil {
+        t.Errorf("ReturnWorkflowRuns() returned error '%v' - expected success after retries", gotErr)
+    }
+
+    if calls != 3 {
+        t.Errorf("expected 3 API calls (2 failures + 1 success) but got %d", calls)
+    }
+
+    if len(gotRuns) != 1 {
+        t.Errorf("expected 1 run but received %d", len(gotRuns))
+    }
+}
+
+func TestReturnWorkflowRunsExhaustsRetriesOn5xx(t *testing.T) {
+
+    // supress logrus
+    log.SetOutput(ioutil.Discard)
+
+    // no backoff delay in tests
+    sleepBetweenRetries = func(int) {}
+
+    client, mux, _, teardown := Setup()
+    defer teardown()
+
+    ctx := context.Background()
+
+    calls := 0
+
+    mux.HandleFunc("/repos/testowner/testrepo/actions/workflows/testfile.yaml/runs", func(w http.ResponseWriter, r *http.Request) {
+
+        TestingMethod(t, r, "GET")
+
+        calls++
+
+        w.WriteHeader(http.StatusServiceUnavailable)
+        fmt.Fprint(w, `{}`)
+    })
+
+    gotRuns, gotErr := ReturnWorkflowRuns("ft/test-branch", ctx, client, "testowner", "testrepo", "testfile.yaml", 20)
+
+    if gotErr == nil {
+        t.Errorf("ReturnWorkflowRuns() expected error after exhausting retries but got nil")
+    }
+
+    if calls != maxAttempts {
+        t.Errorf("expected %d API calls but got %d", maxAttempts, calls)
+    }
+
+    if len(gotRuns) != 0 {
+        t.Errorf("expected no runs but received %d", len(gotRuns))
+    }
+}
+
+func TestReturnWorkflowRunsDoesNotRetryOn404(t *testing.T) {
+
+    // supress logrus
+    log.SetOutput(ioutil.Discard)
+
+    // no backoff delay in tests
+    sleepBetweenRetries = func(int) {}
+
+    client, mux, _, teardown := Setup()
+    defer teardown()
+
+    ctx := context.Background()
+
+    calls := 0
+
+    mux.HandleFunc("/repos/testowner/testrepo/actions/workflows/testfile.yaml/runs", func(w http.ResponseWriter, r *http.Request) {
+
+        TestingMethod(t, r, "GET")
+
+        calls++
+
+        w.WriteHeader(http.StatusNotFound)
+        fmt.Fprint(w, `{}`)
+    })
+
+    _, gotErr := ReturnWorkflowRuns("ft/test-branch", ctx, client, "testowner", "testrepo", "testfile.yaml", 20)
+
+    if gotErr == nil {
+        t.Errorf("ReturnWorkflowRuns() expected error on 404 but got nil")
+    }
+
+    if calls != 1 {
+        t.Errorf("expected exactly 1 API call (404 is permanent) but got %d", calls)
+    }
+}
+

--- a/gh/returnWorkflowRuns_test.go
+++ b/gh/returnWorkflowRuns_test.go
@@ -173,7 +173,7 @@ func TestReturnWorkflowRuns(t *testing.T){
             log.SetOutput(ioutil.Discard)
 
             // no backoff delay in tests
-            sleepBetweenRetries = func(int) {}
+            sleepBetweenRetries = func(context.Context, int) {}
 
             client, mux, _, teardown := Setup()
             defer teardown()
@@ -280,7 +280,7 @@ func TestReturnWorkflowRunsRetriesOn5xx(t *testing.T) {
     log.SetOutput(ioutil.Discard)
 
     // no backoff delay in tests
-    sleepBetweenRetries = func(int) {}
+    sleepBetweenRetries = func(context.Context, int) {}
 
     client, mux, _, teardown := Setup()
     defer teardown()
@@ -339,7 +339,7 @@ func TestReturnWorkflowRunsExhaustsRetriesOn5xx(t *testing.T) {
     log.SetOutput(ioutil.Discard)
 
     // no backoff delay in tests
-    sleepBetweenRetries = func(int) {}
+    sleepBetweenRetries = func(context.Context, int) {}
 
     client, mux, _, teardown := Setup()
     defer teardown()
@@ -379,7 +379,7 @@ func TestReturnWorkflowRunsDoesNotRetryOn404(t *testing.T) {
     log.SetOutput(ioutil.Discard)
 
     // no backoff delay in tests
-    sleepBetweenRetries = func(int) {}
+    sleepBetweenRetries = func(context.Context, int) {}
 
     client, mux, _, teardown := Setup()
     defer teardown()

--- a/gh/returnWorkflowStatus.go
+++ b/gh/returnWorkflowStatus.go
@@ -41,7 +41,7 @@ func ReturnWorkflowRunStatus(ctx context.Context, client *github.Client, owner s
         }).Warn("Transient GitHub API failure fetching workflow run ...")
 
         if attempt < maxAttempts {
-            sleepBetweenRetries(attempt)
+            sleepBetweenRetries(ctx, attempt)
         }
     }
 

--- a/gh/returnWorkflowStatus.go
+++ b/gh/returnWorkflowStatus.go
@@ -18,7 +18,37 @@ func ReturnWorkflowRunStatus(ctx context.Context, client *github.Client, owner s
         "workflowRunId": workflowRunId,
     }).Info("Calling for a previous workflow RunId...")
 
-    run, res, err := client.Actions.GetWorkflowRunByID(ctx, owner, repo, int64(workflowRunId))
+    var run *github.WorkflowRun
+    var res *github.Response
+    var err error
+
+    // Retry transient failures (transport errors, 5xx) — same policy as
+    // ReturnWorkflowRuns, and guards the nil-response dereference below.
+    for attempt := 1; attempt <= maxAttempts; attempt++ {
+
+        run, res, err = client.Actions.GetWorkflowRunByID(ctx, owner, repo, int64(workflowRunId))
+
+        if !retryableAPIFailure(res, err) {
+            break
+        }
+
+        log.WithFields(log.Fields{
+            "attempt":       attempt,
+            "maxAttempts":   maxAttempts,
+            "repo":          repo,
+            "owner":         owner,
+            "workflowRunId": workflowRunId,
+        }).Warn("Transient GitHub API failure fetching workflow run ...")
+
+        if attempt < maxAttempts {
+            sleepBetweenRetries(attempt)
+        }
+    }
+
+    // transport error on every attempt — no HTTP response to inspect
+    if res == nil {
+        return "", &github.Timestamp{time.Time{}}, err
+    }
 
     if res.StatusCode == 404 {
 

--- a/gh/returnWorkflowStatus_test.go
+++ b/gh/returnWorkflowStatus_test.go
@@ -219,6 +219,9 @@ func TestReturnWorkflowRunStatus(t *testing.T){
             // supress logrus
             log.SetOutput(ioutil.Discard)
 
+            // no backoff delay in tests
+            sleepBetweenRetries = func(int) {}
+
             client, mux, _, teardown := Setup()
             defer teardown()
 
@@ -276,4 +279,59 @@ func TestReturnWorkflowRunStatus(t *testing.T){
         })
     }
 
+}
+
+func TestReturnWorkflowRunStatusRetriesOn5xx(t *testing.T) {
+
+    // supress logrus
+    log.SetOutput(ioutil.Discard)
+
+    // no backoff delay in tests
+    sleepBetweenRetries = func(int) {}
+
+    client, mux, _, teardown := Setup()
+    defer teardown()
+
+    ctx := context.Background()
+
+    calls := 0
+
+    mux.HandleFunc("/repos/testowner/testrepo/actions/runs/1111111111", func(w http.ResponseWriter, r *http.Request) {
+
+        TestingMethod(t, r, "GET")
+
+        calls++
+
+        // fail with 503 twice, then succeed
+        if calls < 3 {
+            w.WriteHeader(http.StatusServiceUnavailable)
+            fmt.Fprint(w, `{}`)
+            return
+        }
+
+        w.WriteHeader(http.StatusOK)
+        fmt.Fprint(w, `{
+            "id": 1111111111,
+            "name": "Test Workflow",
+            "run_number": 1,
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2022-12-12T21:34:57Z",
+            "updated_at": "2022-12-12T21:47:06Z"
+        }`)
+    })
+
+    gotStatus, _, gotErr := ReturnWorkflowRunStatus(ctx, client, "testowner", "testrepo", 1111111111)
+
+    if gotErr != nil {
+        t.Errorf("ReturnWorkflowRunStatus() returned error '%v' - expected success after retries", gotErr)
+    }
+
+    if calls != 3 {
+        t.Errorf("expected 3 API calls (2 failures + 1 success) but got %d", calls)
+    }
+
+    if gotStatus != "completed" {
+        t.Errorf("expected status 'completed' but received '%s'", gotStatus)
+    }
 }

--- a/gh/returnWorkflowStatus_test.go
+++ b/gh/returnWorkflowStatus_test.go
@@ -220,7 +220,7 @@ func TestReturnWorkflowRunStatus(t *testing.T){
             log.SetOutput(ioutil.Discard)
 
             // no backoff delay in tests
-            sleepBetweenRetries = func(int) {}
+            sleepBetweenRetries = func(context.Context, int) {}
 
             client, mux, _, teardown := Setup()
             defer teardown()
@@ -287,7 +287,7 @@ func TestReturnWorkflowRunStatusRetriesOn5xx(t *testing.T) {
     log.SetOutput(ioutil.Discard)
 
     // no backoff delay in tests
-    sleepBetweenRetries = func(int) {}
+    sleepBetweenRetries = func(context.Context, int) {}
 
     client, mux, _, teardown := Setup()
     defer teardown()


### PR DESCRIPTION
# Retry GitHub API calls on transport errors and 5xx responses

## Summary

GitHub API calls in `ReturnWorkflowRuns` and `ReturnWorkflowRunStatus` now retry up to 3 attempts with `attempt * 5s` backoff on transport errors and 5xx responses, instead of failing on the first blip. Also fixes a latent nil-pointer panic when the API call returns no HTTP response at all.

## Problem

The binary makes exactly one attempt per GitHub API call. In speckel master publish run [27300](https://github.com/untitledstartup/speckel/actions/runs/28615561942), a transient 503 on the list-workflow-runs call made `shouldExecute` panic on the first attempt:

```
level=warning msg="Request did not succeed: Response status received was not 200 ..." Response Status=503
panic: Failed to complete 'shouldExecute' mode with error No previous runs were returned from Github Actions API
```

The calling workflow's promote step silently skipped and the commit never published. The shell-side swallow is fixed separately in [speckel#45134](https://github.com/untitledstartup/speckel/pull/45134) — that makes a sorter crash loud; this PR makes it rare.

Separately, both `gh/` wrappers dereference `res.StatusCode` before checking `err`, so a pure transport error (`res == nil`, e.g. connection reset) would nil-pointer panic.

## Solution

New `gh/retry.go` holds the shared policy: `maxAttempts = 3`, backoff `attempt * 5s` (a package var so tests can zero it), and `retryableAPIFailure(res, err)` — retry when there is no HTTP response at all, or the status is >= 500. Both API wrappers wrap their call in the retry loop; after exhaustion with no response they return `err` instead of dereferencing. 404/410 and other 4xx are permanent and never retried, and the error strings on final failure are unchanged so callers and log greps stay stable.

The backoff shape (3 attempts, `attempt * 5s`) matches the retry convention speckel workflows already use for `createWorkflowDispatch` calls.

## Blast Radius

Both run modes of the binary, all consuming workflows. Behavior is unchanged on success and on 4xx; the only new behavior is up to 2 extra API calls (max +15s) before a 5xx/transport failure surfaces. `shouldComplete` already re-polls indefinitely on incomplete status, so retries there mainly remove the nil-deref hazard.

## Rollback Plan

Revert the PR and cut a new tag — no state, no config.

## Dependencies

Merging does **not** deploy this: goreleaser builds binaries only on `v*` tag push. A maintainer needs to cut a tag after merge, and consuming runner images pick up the new release.

## Test plan

**Verifiable by agent before merging**
- [x] `TestReturnWorkflowRunsRetriesOn5xx` — 503 twice then 200 → success in exactly 3 calls
- [x] `TestReturnWorkflowRunsExhaustsRetriesOn5xx` — persistent 503 → error after exactly `maxAttempts` calls
- [x] `TestReturnWorkflowRunsDoesNotRetryOn404` — 404 → error after exactly 1 call, no retry
- [x] `TestReturnWorkflowRunStatusRetriesOn5xx` — 503 twice then 200 → status returned in 3 calls
- [x] Full pre-existing suite passes; the existing 504 table cases now exercise the exhaustion path with the same error string

**Cannot be verified before merge**
- [ ] Observe a real transient 5xx being absorbed in a production publish run — requires a live GitHub API incident; cannot be induced
