### PR TITLE
Fix goreleaser release: migrate to v2 (--clean, name_template)

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+          version: v2.17.0
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,4 +1,8 @@
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
+
+project_name: gh-actions-workflow-runs-sorter
+
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -17,16 +21,18 @@ builds:
       - arm
       - arm64
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
-    name_template: '{{.ProjectName}}_{{.Os}}-{{.Arch}}'
+  # goreleaser v2 removed archives.replacements; reproduce the historical
+  # asset names (Darwin/Linux, x86_64/i386) via the name template instead.
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
## Summary

Fix the release pipeline so tags actually publish binaries again: migrate GoReleaser to v2 (`--clean` + a v2-valid config), reproducing the exact historical asset names.

## Problem

The [v0.0.4 release](https://github.com/untitledstartup/gh-actions-workflow-runs-sorter/releases/tag/v0.0.4) published **zero binaries** — [goreleaser run 29362565498](https://github.com/untitledstartup/gh-actions-workflow-runs-sorter/actions/runs/29362565498) died with:

```
⨯ command failed    error=unknown flag: --rm-dist
```

The workflow pinned `version: latest`, which installed **GoReleaser v2.17.0**, but still passed `--rm-dist` — removed in v2 (renamed `--clean`). Two more v2 incompatibilities in `goreleaser.yml` sat behind it and would have failed the build even after the flag: `archives.replacements` was removed, and `snapshot.name_template` was renamed to `version_template`.

The asset names are load-bearing: [mighty-images#294](https://github.com/untitledstartup/mighty-images/pull/294) (`private/gh-runner-scale-set/scripts.sh`) `curl`s them by exact name (`gh-actions-workflow-runs-sorter_Linux-x86_64.tar.gz`, `_Linux-arm64.tar.gz`), so the fix has to preserve them byte-for-byte.

## Solution

**Workflow** ([release-workflow.yaml](.github/workflows/release-workflow.yaml)) — pin `version: v2.17.0`, `args: release --clean`.

**Config** ([goreleaser.yml](goreleaser.yml)) — migrate to v2:
- `version: 2`, plus explicit `project_name` to lock the asset-name prefix regardless of how the repo is checked out.
- Replace the removed `archives.replacements` with a `name_template` reproducing the historical names — title-case the OS (`title .Os`) and map arch (`amd64→x86_64`, `386→i386`, else passthrough).
- `snapshot.name_template` → `version_template`.

Migrating to v2 rather than pinning an old v1: `replacements` is already gone in the last v1 (`v1.26.2`), so a v1 pin couldn't build this config either.

## Blast Radius

Release pipeline only — GoReleaser runs solely on `v*` tag push, so nothing changes until a tag is (re)cut, and the binary's runtime behavior is untouched. The only failure mode that matters — asset names drifting and breaking the mighty-images `curl` — is closed by the name-for-name validation below.

## Rollback Plan

Revert this PR.

## Dependencies

The existing `v0.0.4` tag points at a commit whose workflow still has the bug. After this lands on `main`, **`v0.0.4` must be re-cut** — delete the empty release + tag, then re-tag at the fixed `main` HEAD. That's a maintainer release action, not part of this PR.

## Test plan

**Verifiable by agent before merging**
- [x] `goreleaser v2.17.0 check` (Docker) auto-discovers `goreleaser.yml` and parses the migrated config with no field/type errors — the only error is an environmental `scm: not a git repository` from running against a worktree whose `.git` is a pointer file
- [x] `goreleaser v2.17.0 release --snapshot --clean` (Docker) builds all **6** archives with names **byte-identical to v0.0.3**: `..._Linux-{arm,arm64,i386,x86_64}.tar.gz` + `..._Darwin-{arm64,x86_64}.tar.gz` (darwin-386 and darwin-arm correctly auto-ignored)

*The above is local Docker validation against the exact pinned version (v2.17.0). A live GHA run can't be exercised pre-merge — the release workflow triggers only on `v*` tag push.*

**Cannot be verified before merge**
- [ ] The real GoReleaser GHA run publishes the 6 assets to the `v0.0.4` release — requires re-cutting the tag after merge
